### PR TITLE
build(android): add proguard rules for SDKs and libraries

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -58,6 +58,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+-keep class kotlin.coroutines.**
+-keep class kotlinx.coroutines.**
+
+-keep class com.facetec.sdk.** { *; }
+-keep class com.acesso.acessobio_android.** { *; }
+-keep class io.unico.** { *; }
+
+-keep class br.com.makrosystems.haven.** { *; }
+-keep class HavenSDK.**{ *; }
+-keep class HavenSDK** { *; }


### PR DESCRIPTION
Proguard rules were added to the project to ensure that certain SDKs and libraries are not obfuscated during the build process. This is necessary to ensure that the application functions correctly and that the SDKs and libraries are not broken by the obfuscation process.